### PR TITLE
Check whether extension method is defined and no overload found

### DIFF
--- a/CodingSeb.ExpressionEvaluator/ExpressionEvaluator.cs
+++ b/CodingSeb.ExpressionEvaluator/ExpressionEvaluator.cs
@@ -18,6 +18,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Runtime.CompilerServices;
 
 namespace CodingSeb.ExpressionEvaluator
 {
@@ -835,6 +836,13 @@ namespace CodingSeb.ExpressionEvaluator
         /// Warning : This clearly break the encapsulation principle use this only if you know what you do.
         /// </summary>
         public bool OptionAllowNonPublicMembersAccess { get; set; }
+
+        /// <summary>
+        /// If <c>true</c> On unsuccessful call to an extension method, all defined overloads of that method are detected to resolve whether method is defined and called with wrong arguments or method is not defined.
+        /// If <c>false</c> Unsucessful call to an extension method will always result in "Method {name} is not defined on type {type}"
+        /// Default : true
+        /// </summary>
+        public bool OptionDetectExtensionMethodsOverloadsOnExtensionMethodNotFound { get; set; } = true;
 
         #endregion
 
@@ -1954,6 +1962,33 @@ namespace CodingSeb.ExpressionEvaluator
                                             }
                                             else
                                             {
+                                                if (OptionDetectExtensionMethodsOverloadsOnExtensionMethodNotFound)
+                                                {
+                                                    IEnumerable<MethodInfo> query = from type in StaticTypesForExtensionsMethods
+                                                        where 
+                                                              !type.IsGenericType &&
+                                                              type.IsSealed && 
+                                                              !type.IsNested  
+                                                        from method in type.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                                                        where method.IsDefined(typeof(ExtensionAttribute), false)
+                                                        where method.GetParameters()[0].ParameterType == objType // static extMethod(this outType, ...)
+                                                        select method;
+
+                                                    if (query.Any())
+                                                    {
+                                                        string fnArgsPrint = string.Join(",", funcArgs);
+                                                        string fnOverloadsPrint = "";
+
+                                                        foreach (MethodInfo mi in query)
+                                                        {
+                                                            ParameterInfo[] parInfo = mi.GetParameters();
+                                                            fnOverloadsPrint += string.Join(",", parInfo.Select(x => x.ParameterType.FullName ?? x.ParameterType.Name)) + "\n";
+                                                        } 
+                                                        
+                                                        throw new ExpressionEvaluatorSyntaxErrorException($"[{objType}] extension method \"{varFuncName}\" has no overload for arguments: {fnArgsPrint}. Candidates: {fnOverloadsPrint}");
+                                                    }
+                                                }
+
                                                 throw new ExpressionEvaluatorSyntaxErrorException($"[{objType}] object has no Method named \"{varFuncName}\".");
                                             }
                                         }


### PR DESCRIPTION
Consider this example:

```csharp
public class MyClass {

}

public static class MyClassExt {
    public static int Sum(this MyClass myClass, int a, int b) {
        return a + b;
    }
}

public class Main {
     public staic void Main() {
          ExpressionEvaluator eval = new();
          eval .StaticTypesForExtensionsMethods.Add(typeof(MyClassExt));
          eval.Variables = new Dictionary<string, object> {
               { "myClassProxy", new MyClass() }
          }

          eval.ScriptEvaluate(script);
     }
}

```

Script to evaluate:
```csharp
myClassProxy.Sum(1, 2); // this is ok
myClassProxy.Sum(1) // throws "MyClass object has no Method named Sum"
```

Now this throw is incorrect, there is a method `Sum` in `MyClass` but no matching overload is found when we invoke it. This PR adds two things:

- `OptionDetectExtensionMethodsOverloadsOnExtensionMethodNotFound` if this is toggled on (I've set it to `true` by default) in the situation described above all extension methods from the provided ext. assemblies are scanned and if a method with matching signature is found a new error is thrown
- `MyClass extension method Sum has no overload for arguments: 1. Candidates: int32, int32` (all candidates are enumerated here)

If `OptionDetectExtensionMethodsOverloadsOnExtensionMethodNotFound` is set to `false` this process is ommited and current behavior triggered.
