### PR TITLE
On the fly parameter cast in function evaluation

### DIFF
--- a/CodingSeb.ExpressionEvaluator.Tests/ExpressionEvaluatorTests.cs
+++ b/CodingSeb.ExpressionEvaluator.Tests/ExpressionEvaluatorTests.cs
@@ -1277,6 +1277,32 @@ namespace CodingSeb.ExpressionEvaluator.Tests
             }
         }
 
+        [TestCase("ClassForTest1.Add(1, 5)", ExpectedResult = 6, Category = "On the fly method")]
+        [TestCase("ClassForTest1.Add(1, 5.0)", ExpectedResult = 6, Category = "On the fly method")]
+        public object OnTheFlyEvaluation2(string expression)
+        {
+            ExpressionEvaluator evaluator = new ExpressionEvaluator(new ContextObject1());
+
+            evaluator.EvaluateParameterCast += Evaluator_EvaluateParameterCast;
+
+            evaluator.Namespaces.Add("CodingSeb.ExpressionEvaluator.Tests");
+
+            return evaluator.Evaluate(expression);
+        }
+
+        private void Evaluator_EvaluateParameterCast(object sender, ParameterCastEvaluationEventArg e)
+        {
+            if (e.ParameterType == typeof(ClassForTest2) && e.OriginalArg is int originalArgInt)
+            {
+                e.Argument = new ClassForTest2(originalArgInt);
+            }
+
+            if (e.ParameterType == typeof(ClassForTest2) && e.OriginalArg is double originalArgDouble)
+            {
+                e.Argument = new ClassForTest2((int) originalArgDouble);
+            }
+        }
+
         #endregion
 
         #endregion

--- a/CodingSeb.ExpressionEvaluator.Tests/TestsUtils/ClassForTest1.cs
+++ b/CodingSeb.ExpressionEvaluator.Tests/TestsUtils/ClassForTest1.cs
@@ -26,5 +26,10 @@ namespace CodingSeb.ExpressionEvaluator.Tests
 
         public Func<int, int, int> AddAsDelegate { get; set; } = (nb1, nb2) => nb1 + nb2;
         public static Func<int, int, int> AddAsStaticDelegate { get; set; } = (nb1, nb2) => nb1 + nb2;
+
+        public static int Add(int a, ClassForTest2 b)
+        {
+            return a + b.Value1;
+        }
     }
 }


### PR DESCRIPTION
I have written a custom class that contains a number and SI unit. So that the expression evaluator can handle these values directly, I wrote a custom evaluate function. This can parse an input correctly: `test = 10 ms + 10 ms`.
However, the values can also be without a unit (e.g. the number). However, since I don't know when parsing whether a value as my class or as a number, I can't always wrap the value in my class.

I have tried using the implicit cast operator to catch as much as possible, but still have the problem that when I call a function, it does not recognize that a double can be cast into my class.

For example:
Function in C#: My class is called Quantity
` public Quantity DoStuff(Quantity value);`
Calling this function with a quantity is no problem: `DoStuff(10 ms)` but when I dont have a unit `DoStuff(10)` the 10 is interpreted as int and the function cannot be found, although there exists an implicit cast from int to Quantity. In C# this call is possible.

Hence this approach: If in the method TryToCastMethodParametersToMakeItCallable a parameter cannot be cast, the event is triggered and the developer can decide wether the parameter can be cast to the required type.
