### PR TITLE
Fix if member == null, and EvaluateVariable set Value = null on purpo…

### DIFF
--- a/CodingSeb.ExpressionEvaluator/ExpressionEvaluator.cs
+++ b/CodingSeb.ExpressionEvaluator/ExpressionEvaluator.cs
@@ -2258,6 +2258,7 @@ namespace CodingSeb.ExpressionEvaluator
                                             pushVarValue = false;
                                     }
 
+									bool isVarValueSet = false;
                                     if (member == null && pushVarValue)
                                     {
                                         VariableEvaluationEventArg variableEvaluationEventArg = new VariableEvaluationEventArg(varFuncName, this, obj ?? keepObj, genericsTypes, GetConcreteTypes);
@@ -2267,10 +2268,11 @@ namespace CodingSeb.ExpressionEvaluator
                                         if (variableEvaluationEventArg.HasValue)
                                         {
                                             varValue = variableEvaluationEventArg.Value;
+											isVarValueSet = true;
                                         }
                                     }
 
-                                    if (!isDynamic && varValue == null && pushVarValue)
+                                    if (!isVarValueSet && !isDynamic && varValue == null && pushVarValue)
                                     {
                                         varValue = ((dynamic)member).GetValue(obj);
 


### PR DESCRIPTION
### TL;DR
Fix if member == null, and EvaluateVariable set Value = null on purpose, but throw  "object has no public Property or Member"

### Details
If I evaluate a non existed property like below, an exception will throw.
```
ExpressionEvaluator evaluator = new ExpressionEvaluator();
evaluator.Variables = new Dictionary<string, object>()
{
    { "obj", new { }}
};

// throw an exception like "object has no public Property or Member x ..."
Console.WriteLine(evaluator.Evaluate("obj.x"));
```

However, our requirement is return null instead of the exception. So I made use of the EvaluateVariable like below :
```
evaluator.EvaluateVariable += Evaluator_EvaluateVariable;

private static void Evaluator_PreEvaluateVariable(object sender, VariablePreEvaluationEventArg e)
{
    e.HasValue = true;
    e.Value = null;
}
```
No luck.