### PR TITLE
Fix when EvaluateString a string containing two double quotes, throw exception

### DIFF
--- a/CodingSeb.ExpressionEvaluator/ExpressionEvaluator.cs
+++ b/CodingSeb.ExpressionEvaluator/ExpressionEvaluator.cs
@@ -2924,8 +2924,16 @@ namespace CodingSeb.ExpressionEvaluator
 
                     if (expression.Substring(i)[0] == '"')
                     {
-                        endOfString = true;
-                        stack.Push(resultString.ToString());
+                        if (expression.Substring(i).Length > 1 && expression.Substring(i)[1] == '"')
+                        {
+                            i += 2;
+                            resultString.Append(@"""");
+                        }
+                        else
+                        {
+                            endOfString = true;
+                            stack.Push(resultString.ToString());
+                        }
                     }
                     else if (expression.Substring(i)[0] == '{')
                     {


### PR DESCRIPTION
If a string contains two double quotes (e.g. ""),  it will throw an exception said “Syntax error. Check that no operator is missing”.
```
string expression = "@\"var demo = \"\"abc\"\"; \"";

// throw exception said "Syntax error. Check that no operator is missing"
var output = evaluator.Evaluate(expression);
```



