### PR TITLE
add implicit conversion parameter unit test

### DIFF
--- a/CodingSeb.ExpressionEvaluator.Tests/ExpressionEvaluatorTests.cs
+++ b/CodingSeb.ExpressionEvaluator.Tests/ExpressionEvaluatorTests.cs
@@ -3265,5 +3265,22 @@ namespace CodingSeb.ExpressionEvaluator.Tests
 
         #endregion
 
+        #region Method with implicit parameter
+
+        [Test]
+        [Category("ImplicitParameterMethod")]
+        public void MethodWithImplicitParameter()
+        {
+            ExpressionEvaluator evaluator = new ExpressionEvaluator();
+
+            evaluator.Variables["inObj"] = new MethodArgKeywordClass();
+
+            evaluator.Variables["x"] = "string";
+
+            evaluator.Evaluate("inObj.AcceptStringLike(x)")
+                .ShouldBe(true);
+        }
+
+        #endregion
     }
 }

--- a/CodingSeb.ExpressionEvaluator.Tests/TestsUtils/ClassForImplicitParameter.cs
+++ b/CodingSeb.ExpressionEvaluator.Tests/TestsUtils/ClassForImplicitParameter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CodingSeb.ExpressionEvaluator.Tests.TestsUtils
+{
+    public readonly struct StringLikeParameter
+    {
+        public readonly string Value;
+
+        public StringLikeParameter(string s)
+        {
+            Value = s;
+        }
+
+        public static implicit operator StringLikeParameter(string s) => new StringLikeParameter(s);
+    }
+}

--- a/CodingSeb.ExpressionEvaluator.Tests/TestsUtils/MethodArgKeywordClass.cs
+++ b/CodingSeb.ExpressionEvaluator.Tests/TestsUtils/MethodArgKeywordClass.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using CodingSeb.ExpressionEvaluator.Tests.TestsUtils;
+using System.Linq;
 
 namespace CodingSeb.ExpressionEvaluator.Tests
 {
@@ -53,7 +54,14 @@ namespace CodingSeb.ExpressionEvaluator.Tests
         {
             return val1 + val2;
         }
+
+        public bool AcceptStringLike(StringLikeParameter value)
+        {
+            return true;
+        }
     }
+
+    
 
     public static class MethodArgKeywordClassExtension
     {


### PR DESCRIPTION
This adds the missing unit test for https://github.com/codingseb/ExpressionEvaluator/pull/149