### PR TITLE
Add unaryOperatorsDictionary to manage custom operators that are both unaries and binaries better

### DIFF
--- a/CodingSeb.ExpressionEvaluator/ExpressionEvaluator.cs
+++ b/CodingSeb.ExpressionEvaluator/ExpressionEvaluator.cs
@@ -226,6 +226,12 @@ namespace CodingSeb.ExpressionEvaluator
             ExpressionOperator.UnaryMinus
         };
 
+        protected IDictionary<string, ExpressionOperator> unaryOperatorsDictionary = new Dictionary<string, ExpressionOperator>()
+        {
+            { "+",  ExpressionOperator.UnaryPlus },
+            { "-",  ExpressionOperator.UnaryMinus }
+        };
+
         protected virtual IList<ExpressionOperator> LeftOperandOnlyOperatorsEvaluationDictionary => leftOperandOnlyOperatorsEvaluationDictionary;
         protected virtual IList<ExpressionOperator> RightOperandOnlyOperatorsEvaluationDictionary => rightOperandOnlyOperatorsEvaluationDictionary;
         protected virtual IList<IDictionary<ExpressionOperator, Func<dynamic, dynamic, object>>> OperatorsEvaluations => operatorsEvaluations;
@@ -2748,12 +2754,11 @@ namespace CodingSeb.ExpressionEvaluator
             {
                 string op = match.Value;
 
-                if (op.Equals("+") && (stack.Count == 0 || (stack.Peek() is ExpressionOperator previousOp && !LeftOperandOnlyOperatorsEvaluationDictionary.Contains(previousOp))))
-                    stack.Push(ExpressionOperator.UnaryPlus);
-                else if (op.Equals("-") && (stack.Count == 0 || (stack.Peek() is ExpressionOperator previousOp2 && !LeftOperandOnlyOperatorsEvaluationDictionary.Contains(previousOp2))))
-                    stack.Push(ExpressionOperator.UnaryMinus);
+                if (unaryOperatorsDictionary.ContainsKey(op) && (stack.Count == 0 || (stack.Peek() is ExpressionOperator previousOp && !LeftOperandOnlyOperatorsEvaluationDictionary.Contains(previousOp))))
+                    stack.Push(unaryOperatorsDictionary[op]);
                 else
                     stack.Push(operatorsDictionary[op]);
+
                 i += op.Length - 1;
                 return true;
             }


### PR DESCRIPTION
Add unary operators so they can be added to.

Eg the code below adds three new ones, as described in #159 .

Sadly I can't get the unit tests working as I don't have framework installed.

``` c#
/// <summary>
/// Adds 6502 ASM extensions to the expression evaluator.
/// </summary>
public class Asm6502ExpressionEvaluator : ExpressionEvaluator
{
    protected new static readonly IList<ExpressionOperator> rightOperandOnlyOperatorsEvaluationDictionary =
        BaseExpressionEvaluator.rightOperandOnlyOperatorsEvaluationDictionary
            .ToList()
            .FluidAdd(Asm6502Operator.LowByte)
            .FluidAdd(Asm6502Operator.HighByte)
            .FluidAdd(Asm6502Operator.TopByte);

    protected new static readonly IList<IDictionary<ExpressionOperator, Func<dynamic, dynamic, object>>> operatorsEvaluations =
        BaseExpressionEvaluator.operatorsEvaluations
            .Copy()
            .AddOperatorEvaluationAtNewLevelAfter(Asm6502Operator.LowByte, (left, right) => right & 0xff, ExpressionOperator.UnaryPlus)
            .AddOperatorEvaluationAtLevelOf(Asm6502Operator.HighByte, (left, right) => (right & 0xff00) >> 8, Asm6502Operator.LowByte)
            .AddOperatorEvaluationAtLevelOf(Asm6502Operator.TopByte, (left, right) => (right & 0xff0000) >> 16, Asm6502Operator.LowByte);

    protected override IList<ExpressionOperator> RightOperandOnlyOperatorsEvaluationDictionary => rightOperandOnlyOperatorsEvaluationDictionary;
 
    protected override IList<IDictionary<ExpressionOperator, Func<dynamic, dynamic, object>>> OperatorsEvaluations => operatorsEvaluations;

    protected override void Init()
    {
        unaryOperatorsDictionary.Add(">", Asm6502Operator.LowByte);
        unaryOperatorsDictionary.Add("<", Asm6502Operator.HighByte);
        unaryOperatorsDictionary.Add("^", Asm6502Operator.TopByte);
    }
}

internal class Asm6502Operator : ExpressionOperator
{
    public static readonly ExpressionOperator LowByte = new Asm6502Operator();
    public static readonly ExpressionOperator HighByte = new Asm6502Operator();
    public static readonly ExpressionOperator TopByte = new Asm6502Operator();
}
```