### PR TITLE
Support for nested ternary

### DIFF
--- a/CodingSeb.ExpressionEvaluator.Tests/ExpressionEvaluatorTests.cs
+++ b/CodingSeb.ExpressionEvaluator.Tests/ExpressionEvaluatorTests.cs
@@ -621,6 +621,10 @@ namespace CodingSeb.ExpressionEvaluator.Tests
         [TestCase("Abs(-4) > 10 / 2 ? (true ? 6 : 3+2) : (false ? Abs(-18) : 100 / 2)", ExpectedResult = 50, Category = "Conditional Operator t ? x : y")]
         [TestCase("Abs(-4) > 10 / 2?(true ? 6 : 3+2):(false?Abs(-18):100 / 2)", ExpectedResult = 50, Category = "Conditional Operator t ? x : y")]
         [TestCase("1==1?true:false", ExpectedResult = true, Category = "Conditional Operator t ? x : y")]
+        [TestCase("1 == 2 ? 3 == 4 ? 1 : 0 : 0", ExpectedResult = 0, Category = "Conditional Operator t ? x : y")]
+        [TestCase("1 == 1 ? 3 == 3 ? 1 : 0 : 0", ExpectedResult = 1, Category = "Conditional Operator t ? x : y")]
+        [TestCase("false ? true ? 10 : 20 : 30", ExpectedResult = 30, Category = "Conditional Operator t ? x : y")]
+        [TestCase("true ? false ? 10 : 20 : 30", ExpectedResult = 20, Category = "Conditional Operator t ? x : y")]
         #endregion
 
         #region Math Constants

--- a/CodingSeb.ExpressionEvaluator/ExpressionEvaluator.cs
+++ b/CodingSeb.ExpressionEvaluator/ExpressionEvaluator.cs
@@ -2808,6 +2808,8 @@ namespace CodingSeb.ExpressionEvaluator
                 bool condition = (bool)ProcessStack(stack);
 
                 string restOfExpression = expression.Substring(i + 1);
+                // Track nesting level of ternary operators
+                int ternaryNestingLevel = 0; 
 
                 for (int j = 0; j < restOfExpression.Length; j++)
                 {
@@ -2825,15 +2827,29 @@ namespace CodingSeb.ExpressionEvaluator
                         j++;
                         GetExpressionsBetweenParenthesesOrOtherImbricableBrackets(restOfExpression, ref j, false);
                     }
+                    else if (s2.Equals("?"))
+                    {
+                        // Found nested ternary operator, increase nesting level
+                        ternaryNestingLevel++;
+                    }
                     else if (s2.Equals(":"))
                     {
-                        stack.Clear();
+                        if (ternaryNestingLevel == 0)
+                        {
+                            // This colon belongs to our ternary operator
+                            stack.Clear();
 
-                        stack.Push(condition ? Evaluate(restOfExpression.Substring(0, j)) : Evaluate(restOfExpression.Substring(j + 1)));
+                            stack.Push(condition ? Evaluate(restOfExpression.Substring(0, j)) : Evaluate(restOfExpression.Substring(j + 1)));
 
-                        i = expression.Length;
+                            i = expression.Length;
 
-                        return true;
+                            return true;
+                        }
+                        else
+                        {
+                            // This colon belongs to a nested ternary operator, decrease nesting level
+                            ternaryNestingLevel--;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fix for #167: Handle nested ternary expressions without requiring parentheses